### PR TITLE
Fix empty whitespace on right side of browser

### DIFF
--- a/_includes/jumbotron.html
+++ b/_includes/jumbotron.html
@@ -1,25 +1,27 @@
-<div class="jumbotron">
-  <div class="container">
-    <div class="row">
-      <div class="col-sm-2">
-        <img src="assets/citylogo.png" alt="City of Santa Monica logo" class="logo" />
-        <img src="assets/chamberlogo.jpg" alt="Santa Monica Chamber of Commerce logo" class="logo" />
-      </div>
-      <div class="col-sm-10">
-        <div class="row">
-          <div class="col-sm-12">
-            <h1>{Hack the Beach}</h1>
-            <h2>For The National Day of Civic Hacking</h2>
-          </div>
+<div class="row">
+  <div class="jumbotron">
+    <div class="container">
+      <div class="row">
+        <div class="col-sm-2">
+          <img src="assets/citylogo.png" alt="City of Santa Monica logo" class="logo" />
+          <img src="assets/chamberlogo.jpg" alt="Santa Monica Chamber of Commerce logo" class="logo" />
         </div>
-        <div class="row">
-          <div class="col-sm-6">
-            <ul>
-              <li>June 6, 2015</li>
-              <li>Santa Monica Main Library</li>
-            </ul>
-            <a class="btn btn-lg" target="_blank" href="http://www.eventbrite.com/e/city-of-santa-monica-presents-hack-the-beach-tech-tackles-traffic-tickets-16847693906">RSVP</a>
-            <a class="btn btn-lg" href="#disqus_thread">Ask Questions</a>
+        <div class="col-sm-10">
+          <div class="row">
+            <div class="col-sm-12">
+              <h1>{Hack the Beach}</h1>
+              <h2>For The National Day of Civic Hacking</h2>
+            </div>
+          </div>
+          <div class="row">
+            <div class="col-sm-6">
+              <ul>
+                <li>June 6, 2015</li>
+                <li>Santa Monica Main Library</li>
+              </ul>
+              <a class="btn btn-lg" target="_blank" href="http://www.eventbrite.com/e/city-of-santa-monica-presents-hack-the-beach-tech-tackles-traffic-tickets-16847693906">RSVP</a>
+              <a class="btn btn-lg" href="#disqus_thread">Ask Questions</a>
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
If any div has a `.row` as a sibling and isn't a `.row` itself, then it'll cause this padding issue because of Bootstrap's negative margin and positive padding thing.

Here's what I mean, the jumbotron isn't extending the same length as all of the other sections of the website. Just wrapping the jumbotron in a `.row` fixes this.

![screen shot 2015-05-28 at 9 47 40 pm](https://cloud.githubusercontent.com/assets/1246453/7876602/6262027e-0583-11e5-8b8f-6f7bbb8c9fca.png)
