### PR TITLE
Fix unnecessary Bootstrap rows causing scrolling

### DIFF
--- a/_includes/jumbotron.html
+++ b/_includes/jumbotron.html
@@ -1,27 +1,25 @@
-<div class="row">
-  <div class="jumbotron">
-    <div class="container">
-      <div class="row">
-        <div class="col-sm-2">
-          <img src="assets/citylogo.png" alt="City of Santa Monica logo" class="logo" />
-          <img src="assets/chamberlogo.jpg" alt="Santa Monica Chamber of Commerce logo" class="logo" />
-        </div>
-        <div class="col-sm-10">
-          <div class="row">
-            <div class="col-sm-12">
-              <h1>{Hack the Beach}</h1>
-              <h2>For The National Day of Civic Hacking</h2>
-            </div>
+<div class="jumbotron">
+  <div class="container">
+    <div class="row">
+      <div class="col-sm-2">
+        <img src="assets/citylogo.png" alt="City of Santa Monica logo" class="logo" />
+        <img src="assets/chamberlogo.jpg" alt="Santa Monica Chamber of Commerce logo" class="logo" />
+      </div>
+      <div class="col-sm-10">
+        <div class="row">
+          <div class="col-sm-12">
+            <h1>{Hack the Beach}</h1>
+            <h2>For The National Day of Civic Hacking</h2>
           </div>
-          <div class="row">
-            <div class="col-sm-6">
-              <ul>
-                <li>June 6, 2015</li>
-                <li>Santa Monica Main Library</li>
-              </ul>
-              <a class="btn btn-lg" target="_blank" href="http://www.eventbrite.com/e/city-of-santa-monica-presents-hack-the-beach-tech-tackles-traffic-tickets-16847693906">RSVP</a>
-              <a class="btn btn-lg" href="#disqus_thread">Ask Questions</a>
-            </div>
+        </div>
+        <div class="row">
+          <div class="col-sm-6">
+            <ul>
+              <li>June 6, 2015</li>
+              <li>Santa Monica Main Library</li>
+            </ul>
+            <a class="btn btn-lg" target="_blank" href="http://www.eventbrite.com/e/city-of-santa-monica-presents-hack-the-beach-tech-tackles-traffic-tickets-16847693906">RSVP</a>
+            <a class="btn btn-lg" href="#disqus_thread">Ask Questions</a>
           </div>
         </div>
       </div>

--- a/css/main.scss
+++ b/css/main.scss
@@ -63,7 +63,7 @@ body {
   }
 }
 
-.row.header {
+.header {
   background-color: $sectionHeaderColor;
   color: $white;
   font-family: $hackFont;
@@ -91,7 +91,7 @@ body {
   }
 }
 
-.row.section {
+.section {
   padding: $sectionSpacer 0;
 }
 

--- a/index.html
+++ b/index.html
@@ -5,23 +5,19 @@ layout: default
 {% include jumbotron.html %}
 
 {% for section in site.data.layout %}
-<div class="row header {{ section.name }}">
-  <div class="col-md-12">
-    <div class="container">
-      {% if section.header.icon %}
-      <i class="fa fa-fw {{ section.header.icon }} lead text-center"></i>
-      {% else if section.header.text %}
-      <h2 class="text-center">{{ section.header.text }}</h2>
-      {% endif %}
-    </div>
+<div class="header {{ section.name }}">
+  <div class="container">
+    {% if section.header.icon %}
+    <i class="fa fa-fw {{ section.header.icon }} lead text-center"></i>
+    {% else if section.header.text %}
+    <h2 class="text-center">{{ section.header.text }}</h2>
+    {% endif %}
   </div>
 </div>
 
-<div class="row section {{ section.name }}">
-  <div class="col-md-12">
-    <div class="container">
+<div class="section {{ section.name }}">
+  <div class="container">
     {% include {{ section.name }}.html %}
-    </div>
   </div>
 </div>
 {% endfor %}


### PR DESCRIPTION
My bad, one more pull request... Currently there's a slight horizontal scroll because of how Bootstrap handles paddings/margins with rows. I accidentally encouraged this in my last pull request because I hadn't noticed it but if a section should span the entire browser, then there's no need for a `.row` and `.col-*-12` setup. For example, the "Breakout Sessions" contains a `.row` because it has two columns but the "Breakout Session" parent div doesn't need to be a `.row`.

Don't know if my rambling made any sense at all... Sorry!

You can compare the slight scrolling here (minus the fancy font): http://projects.allejo.io/hackthebeach/
