### PR TITLE
Move to Bootstrap 4 beta

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,3 +7,7 @@ require 'open-uri'
 versions = JSON.parse(open('https://pages.github.com/versions.json').read)
 
 gem 'github-pages', versions['github-pages']
+
+group :jekyll_plugins do
+    gem 'jekyll-livereload'
+end

--- a/_includes/contest/2015-2016/challenges.html
+++ b/_includes/contest/2015-2016/challenges.html
@@ -1,9 +1,9 @@
 <div class="row">
   {% for challenge in site.data.challenges["2015-2016"] %}
-  <div class="col-md-4 challenge text-center">
-    <h2 class="text-center">{{ challenge.topic }}</h2>
-    <img class="img-responsive img-rounded" src="{{ challenge.logo }}" alt="{{ challenge.topic }}" />
-    {{ challenge.blurb }}
-  </div>
+    <div class="col-md-4 challenge text-center">
+      <h2 class="mt-0 text-center">{{ challenge.topic }}</h2>
+      <img class="img-fluid rounded mx-auto mb-3" src="{{ challenge.logo }}" alt="{{ challenge.topic }}" />
+      {{ challenge.blurb }}
+    </div>
   {% endfor %}
 </div>

--- a/_includes/contest/2017-2018/challenges.html
+++ b/_includes/contest/2017-2018/challenges.html
@@ -1,21 +1,16 @@
-<div class="row">
-  <div class="col-md-12 text-left">
-    <p class="lead">We invite you to submit solutions that meet one or more of the below design challenges. <a target="_blank" href="https://go.citygro.ws/flow_templates/982/initiated_flows/new">Applications</a> accepted from July 6, 2017 to September 4, 2017. The contest will run through the end of 2017.</p>
-  </div>
-</div>
+<p class="lead">We invite you to submit solutions that meet one or more of the below design challenges. <a target="_blank" href="https://go.citygro.ws/flow_templates/982/initiated_flows/new">Applications</a> accepted from July 6, 2017 to September 4, 2017. The contest will run through the end of 2017.</p>
 
 {% for challenge in site.data.challenges["2017-2018"] %}
-<hr />
-<div class="row challenge">
-  <div class="col-md-3">
-    <h3>{{ challenge.topic }}</h3>
-    <img class="img-rounded media-object" src="{{ challenge.logo }}" alt="{{ challenge.topic }}" />
+  <div class="row challenge border border-bottom-0 border-left-0 border-right-0 py-4">
+    <div class="col-md-3">
+      <h3>{{ challenge.topic }}</h3>
+      <img class="rounded" src="{{ challenge.logo }}" alt="{{ challenge.topic }}" />
+    </div>
+    <div class="col-md-9">
+      {% for detail in challenge.details %}
+        {{ detail.blurb }}
+        <p><strong>{{ detail.question }}</strong></p>
+      {% endfor %}
+    </div>
   </div>
-  <div class="col-md-9">
-    {% for detail in challenge.details %}
-      {{ detail.blurb }}
-      <p><strong>{{ detail.question }}</strong></p>
-    {% endfor %}
-  </div>
-</div>
 {% endfor %}

--- a/_includes/contest/2017-2018/details.html
+++ b/_includes/contest/2017-2018/details.html
@@ -1,85 +1,75 @@
-<div class="row">
-  <div class="col-md-12 text-left">
-    <h3>Timeline</h3>
-    <p>The application period is open July 6 to September 4, 2017. In addition to accepting applications, we will hold monthly events through the rest of the year. These events are an opportunity to learn more about how your City works, what your colleagues are working on, and network with other professionals in the area. Each event will have a keynote speaker corresponding to one or more of the design challenge areas. Please note that all dates are subject to change.</p>
+<h3>Timeline</h3>
+<p>The application period is open July 6 to September 4, 2017. In addition to accepting applications, we will hold monthly events through the rest of the year. These events are an opportunity to learn more about how your City works, what your colleagues are working on, and network with other professionals in the area. Each event will have a keynote speaker corresponding to one or more of the design challenge areas. Please note that all dates are subject to change.</p>
 
-    <h4>July 6, 2017 – The Contest Kickoff</h4>
-    <p>Hackers from all walks of life were on hand as we unveiled attended the Contest Kickoff, hosted by ExpertDojo. We spoke to people from different sectors, different countries, and different interests. The common thread was the group’s mission towards making Santa Monica an even better community than it is today. The picturesque Santa Monica summer evening and the outdoor venue provided just the right environment for networking, exchange of ideas, and learning about what’s new in the Contest for 2017.</p>
-    <p><a href="http://www.youtube.com/watch?v=9KVB4f1fPNA&t=16m37s" target="_blank">City Manager Rick Cole gave a spirited keynote speech</a>, inviting the community to help make Santa Monica a beacon of light for the rest of the world to learn from and aspire towards.</p>
+<h4>July 6, 2017 – The Contest Kickoff</h4>
+<p>Hackers from all walks of life were on hand as we unveiled attended the Contest Kickoff, hosted by ExpertDojo. We spoke to people from different sectors, different countries, and different interests. The common thread was the group’s mission towards making Santa Monica an even better community than it is today. The picturesque Santa Monica summer evening and the outdoor venue provided just the right environment for networking, exchange of ideas, and learning about what’s new in the Contest for 2017.</p>
+<p><a href="http://www.youtube.com/watch?v=9KVB4f1fPNA&t=16m37s" target="_blank">City Manager Rick Cole gave a spirited keynote speech</a>, inviting the community to help make Santa Monica a beacon of light for the rest of the world to learn from and aspire towards.</p>
 
 
-    <h4>August 23, 2017 – Inside Edge</h4>
-    <p>Meet subject matter experts from each of the design challenge areas. This is your opportunity to gain an inside edge by crafting some or part of your pitch and project to speak to real issues faced by City leaders. Co-hosted by <a href="http://hackforla.org" target="_blank">Hack for LA</a> and featuring a keynote from representatives of <a href="https://www.codeforamerica.org/" target="_blank">Code for America</a>:</p>
-    <div class="media">
-      <div class="media-left">
-        <img class="media-object img-rounded" width="100" height="100" src="{{ site.baseurl }}/assets/neil-khare.png" alt="Neil Khare">
-      </div>
-      <div class="media-body">
-        <h5 class="media-heading"><strong>Neil Khare, Director of Public Partnerships</strong></h5>
-        <p>Neil came to Code for America after a career in both government and technology. Previously, Neil worked at AVIA, a healthcare innovation firm, and managed strategic initiatives at Cleversafe, an enterprise data storage firm acquired by IBM. He also served as Deputy Chief of Staff and Policy Director for Cook County Board President Toni Preckwinkle, leading strategic planning and execution across the County's key service areas: public safety & justice, health care, and economic development. He played a critical role in closing budget gaps of over $1 billion at Cook County in a fiscally responsible manner. Neil received both his MBA and BA from Northwestern University.</p>
-      </div>
-    </div>
-    <div class="media">
-      <div class="media-left">
-        <img class="media-object img-rounded" width="100" height="100" src="{{ site.baseurl }}/assets/caitlin-docker.jpg" alt="Caitlin Docker">
-      </div>
-      <div class="media-body">
-        <h5 class="media-heading"><strong>Caitlin Docker, Sr. Manager of Partnerships and Growth</strong></h5>
-        <p>Caitlin's goal is to close the participation gap in CalFresh state-wide, and she's currently working to bring GetCalFresh to each county in California. Her work focuses on improving the delivery of essential government services by deploying concepts like user research and data-driven decision making. She brings 5+ years experience in coalition building and working with the U.S. federal government to her work. Caitlin earned her bachelor's degree from American University in Washington, D.C.</p>
-      </div>
-    </div>
-
-
-    <h4>September 2017 – Pitch Night</h4>
-    <p>Every candidate who passes an initial screening will be given a lightning pitch opportunity at this event. Initial screening will filter out any projects which do not address one or more of the design challenges.</p>
-    <div class="media">
-      <div class="media-left">
-        <img class="media-object img-rounded" width="100" src="{{ site.baseurl }}/assets/jonathan-mooney.jpg" alt="Jonathan Mooney">
-      </div>
-      <div class="media-body">
-        <h5 class="media-heading"><strong>Jonathan Mooney, Public Speaker, Author</strong></h5>
-        <p>Jonathan is a widely sought after speaker whose work has been featured in The New York Times, The Los Angeles Times, The Chicago Tribune, USA Today, HBO, NPR, ABC News, New York Magazine, The Washington Post, and The Boston Globe. He is currently the chief social impact officer of an early-stage startup based here in Los Angeles called coParenter which is trying to support and empower the 30 million individuals who are coparenting as a result of divorce separation or never being married.</p>
-      </div>
-    </div>
-    
-    <h4>December, 2017 – Final Pitch Night</h4>
-    <p>Each Finalist will give their final pitch directly to the judges and the rest of the community. Judges will deliberate to select a winner. Winner will be unveiled the following month at the State of the City Address. </p>
-
-    <h4>January, 2018 – State of the City</h4>
-    <p>The winner will be announced and invited on stage at the 2018 State of the City ceremony.</p>
-
-    <hr />
-
-    <h3>Judging</h3>
-    <h4>The Basics</h4>
-    <ul>
-      <li>Your project must provide a solution addressing one or more of this year’s design challenges.</li>
-      <li>Your project must be in a state to be implemented no later than March, 2018. Remember, we want real solutions to real problems. </li>
-    </ul>
-    <p>If your proposal meets these marks, you will automatically be added to the City's list of qualified vendors (i.e. you will be deemed responsive to a process we refer to as Request for Qualified Vendors) and you will have an opportunity to pitch during the September event.
-
-    <h4>Becoming a Finalist and Winner</h4>
-    <p>We will use a panel of experts across multiple disciplines to whittle the initial list of applicants down to n no more than 10 finalists. Our Contest judges will conduct a final evaluation of all projects at our December events. Both the panel of experts and the judges will be using the final criteria to rate projects:</p>
-    <ul>
-      <li><strong>Viability (40%)</strong> Consider cost to develop, return on investment, cost of maintenance, scalability, user adoption and other barriers to success. Hack the Beach is about creating real solutions for real problems; will your solution be viable for your target audience(s)?</li>
-      <li><strong>Value (40%)</strong> Great ideas are common, great applications are not. Does this product demonstrate the capacity to go beyond being just a good idea to being a solid product that people will actually use and benefit from?</li>
-      <li><strong>Growth (20%)</strong> What is the long-term outlook for the product? Is it a one-off, or an evolving product which can morph, adapt, and provide value over time?</li>
-    </ul>
-
-    <hr />
-
-    <h3>What's in it For Me? </h3>
-    <p>You mean aside from having a positive impact on your community? Well, we have some prizes if you’re into that sort of thing.</p>
-    <ul>
-
-      <li><b>Behind the Scenes Tour of Hyperloop One.</b>Your team will go behind the scenes with one of the most exciting transportation technology innovators. </li>
-      <li><b>Workspace from Cross Campus</b>. The winning entry will receive one complimentary year of Resident Membership at Cross Campus (for up to 4 team members) valid at any of their locations: Santa Monica, Downtown LA, Old Pasadena, or South Bay (opening Dec 2017). A Resident Membership will grant you 24/7 access to the shared workspace at all of their locations, access to all member amenities and member only events, unlimited business resources, and conference room credits.</li>
-      <li><b>Dinner with City Manager Rick Cole and Mayor Ted Winterer at Rustic Canyon.</b> You will have the unique opportunity to interact with our City Manager and Mayor in an intimate setting.</li>
-      <li><b>Growth Hacking at Expert Dojo.</b> Your team will receive a complimentary membership in Expert Dojo's <a href="https://expertdojo.com/growth-hacking/">Growth Hacking</a> program.</li>
-      <li><b>Incubator Interview with Hacker Fund</b> Automatic bid to interview for the Hacker Fund Incubator program in January 2018.  Hacker Fund is an incubator for charitable, educational, and scientific projects that drive social change around the world. Members of the incubator receive tax-deductible status, tools to fundraise, and access to a global network of donors and volunteers.</li>
-      <li><b>Talent Development at General Assembly.</b>Your team will receive credits for short-form classes and workshops at General Assembly. </li>
-      <li>Every application that passes the initial screening will be added to a Request for Qualified Vendors list for the City of Santa Monica. This means that the City now knows who you are, what you do, and has the ability to reach out to you should there be work that you or your company can perform for the City. </li>
-      <li>Ongoing promotion of your contributions by the City of Santa Monica, the Santa Monica Chamber of Commerce, and other project partners. </li>
-    </ul>
+<h4>August 23, 2017 – Inside Edge</h4>
+<p>Meet subject matter experts from each of the design challenge areas. This is your opportunity to gain an inside edge by crafting some or part of your pitch and project to speak to real issues faced by City leaders. Co-hosted by <a href="http://hackforla.org" target="_blank">Hack for LA</a> and featuring a keynote from representatives of <a href="https://www.codeforamerica.org/" target="_blank">Code for America</a>:</p>
+<div class="media">
+  <img class="mr-3 rounded" width="100" height="100" src="{{ site.baseurl }}/assets/neil-khare.png" alt="Neil Khare">
+  <div class="media-body">
+    <h5 class="mt-0"><strong>Neil Khare, Director of Public Partnerships</strong></h5>
+    <p>Neil came to Code for America after a career in both government and technology. Previously, Neil worked at AVIA, a healthcare innovation firm, and managed strategic initiatives at Cleversafe, an enterprise data storage firm acquired by IBM. He also served as Deputy Chief of Staff and Policy Director for Cook County Board President Toni Preckwinkle, leading strategic planning and execution across the County's key service areas: public safety & justice, health care, and economic development. He played a critical role in closing budget gaps of over $1 billion at Cook County in a fiscally responsible manner. Neil received both his MBA and BA from Northwestern University.</p>
   </div>
 </div>
+<div class="media">
+  <img class="mr-3 rounded" width="100" height="100" src="{{ site.baseurl }}/assets/caitlin-docker.jpg" alt="Caitlin Docker">
+  <div class="media-body">
+    <h5 class="mt-0"><strong>Caitlin Docker, Sr. Manager of Partnerships and Growth</strong></h5>
+    <p>Caitlin's goal is to close the participation gap in CalFresh state-wide, and she's currently working to bring GetCalFresh to each county in California. Her work focuses on improving the delivery of essential government services by deploying concepts like user research and data-driven decision making. She brings 5+ years experience in coalition building and working with the U.S. federal government to her work. Caitlin earned her bachelor's degree from American University in Washington, D.C.</p>
+  </div>
+</div>
+
+
+<h4>September 2017 – Pitch Night</h4>
+<p>Every candidate who passes an initial screening will be given a lightning pitch opportunity at this event. Initial screening will filter out any projects which do not address one or more of the design challenges.</p>
+<div class="media">
+  <img class="mr-3 rounded" width="100" src="{{ site.baseurl }}/assets/jonathan-mooney.jpg" alt="Jonathan Mooney">
+  <div class="media-body">
+    <h5 class="mt-0"><strong>Jonathan Mooney, Public Speaker, Author</strong></h5>
+    <p>Jonathan is a widely sought after speaker whose work has been featured in The New York Times, The Los Angeles Times, The Chicago Tribune, USA Today, HBO, NPR, ABC News, New York Magazine, The Washington Post, and The Boston Globe. He is currently the chief social impact officer of an early-stage startup based here in Los Angeles called coParenter which is trying to support and empower the 30 million individuals who are coparenting as a result of divorce separation or never being married.</p>
+  </div>
+</div>
+
+<h4>December, 2017 – Final Pitch Night</h4>
+<p>Each Finalist will give their final pitch directly to the judges and the rest of the community. Judges will deliberate to select a winner. Winner will be unveiled the following month at the State of the City Address. </p>
+
+<h4>January, 2018 – State of the City</h4>
+<p>The winner will be announced and invited on stage at the 2018 State of the City ceremony.</p>
+
+<hr />
+
+<h3>Judging</h3>
+<h4>The Basics</h4>
+<ul>
+  <li>Your project must provide a solution addressing one or more of this year’s design challenges.</li>
+  <li>Your project must be in a state to be implemented no later than March, 2018. Remember, we want real solutions to real problems. </li>
+</ul>
+<p>If your proposal meets these marks, you will automatically be added to the City's list of qualified vendors (i.e. you will be deemed responsive to a process we refer to as Request for Qualified Vendors) and you will have an opportunity to pitch during the September event.
+
+<h4>Becoming a Finalist and Winner</h4>
+<p>We will use a panel of experts across multiple disciplines to whittle the initial list of applicants down to n no more than 10 finalists. Our Contest judges will conduct a final evaluation of all projects at our December events. Both the panel of experts and the judges will be using the final criteria to rate projects:</p>
+<ul>
+  <li><strong>Viability (40%)</strong> Consider cost to develop, return on investment, cost of maintenance, scalability, user adoption and other barriers to success. Hack the Beach is about creating real solutions for real problems; will your solution be viable for your target audience(s)?</li>
+  <li><strong>Value (40%)</strong> Great ideas are common, great applications are not. Does this product demonstrate the capacity to go beyond being just a good idea to being a solid product that people will actually use and benefit from?</li>
+  <li><strong>Growth (20%)</strong> What is the long-term outlook for the product? Is it a one-off, or an evolving product which can morph, adapt, and provide value over time?</li>
+</ul>
+
+<hr />
+
+<h3>What's in it For Me? </h3>
+<p>You mean aside from having a positive impact on your community? Well, we have some prizes if you’re into that sort of thing.</p>
+<ul>
+
+  <li><b>Behind the Scenes Tour of Hyperloop One.</b>Your team will go behind the scenes with one of the most exciting transportation technology innovators. </li>
+  <li><b>Workspace from Cross Campus</b>. The winning entry will receive one complimentary year of Resident Membership at Cross Campus (for up to 4 team members) valid at any of their locations: Santa Monica, Downtown LA, Old Pasadena, or South Bay (opening Dec 2017). A Resident Membership will grant you 24/7 access to the shared workspace at all of their locations, access to all member amenities and member only events, unlimited business resources, and conference room credits.</li>
+  <li><b>Dinner with City Manager Rick Cole and Mayor Ted Winterer at Rustic Canyon.</b> You will have the unique opportunity to interact with our City Manager and Mayor in an intimate setting.</li>
+  <li><b>Growth Hacking at Expert Dojo.</b> Your team will receive a complimentary membership in Expert Dojo's <a href="https://expertdojo.com/growth-hacking/">Growth Hacking</a> program.</li>
+  <li><b>Incubator Interview with Hacker Fund</b> Automatic bid to interview for the Hacker Fund Incubator program in January 2018.  Hacker Fund is an incubator for charitable, educational, and scientific projects that drive social change around the world. Members of the incubator receive tax-deductible status, tools to fundraise, and access to a global network of donors and volunteers.</li>
+  <li><b>Talent Development at General Assembly.</b>Your team will receive credits for short-form classes and workshops at General Assembly. </li>
+  <li>Every application that passes the initial screening will be added to a Request for Qualified Vendors list for the City of Santa Monica. This means that the City now knows who you are, what you do, and has the ability to reach out to you should there be work that you or your company can perform for the City. </li>
+  <li>Ongoing promotion of your contributions by the City of Santa Monica, the Santa Monica Chamber of Commerce, and other project partners. </li>
+</ul>

--- a/_includes/contest/2017-2018/judges.html
+++ b/_includes/contest/2017-2018/judges.html
@@ -4,7 +4,7 @@
         {% capture name %}{{ judge.fname }} {{ judge.lname }}{% endcapture %}
         {% assign slugified = name | replace: ' ', '-' | downcase %}
         <div class="judge col-sm-6 col-md-4">
-            <figure class="headshot mb2">
+            <figure class="headshot mb-2">
                 <img src="/assets/{{ slugified }}.jpg" alt="{{ name }}'s headshot'">
             </figure>
 

--- a/_includes/contest/jumbotron.html
+++ b/_includes/contest/jumbotron.html
@@ -1,8 +1,11 @@
 <h1>Ready to Take Your City to the Next Level?</h1>
 <p>Hack the Beach: The Contest is an annual challenge allowing anyone in the community to submit proposals for apps, ideas, processes, and/or technology to help Santa Monica improve our sense of Community and Civic Engagement.</p>
-<p class="pull-left">
-  <a class="btn btn-default btn-lg" href="{{ site.baseurl }}/contest/current">The Contest: 2017</a>
-</p>
-<p class="pull-right">
-  <a class="btn btn-default btn-lg" target="_blank" href="https://go.citygro.ws/flow_templates/982/initiated_flows/new">Apply Now!</a>
-</p>
+
+<div class="row">
+  <div class="col">
+    <a class="btn btn-default btn-lg" href="{{ site.baseurl }}/contest/current">The Contest: 2017</a>
+  </div>
+  <div class="col text-sm-right">
+    <a class="btn btn-default btn-lg" target="_blank" href="https://go.citygro.ws/flow_templates/982/initiated_flows/new">Apply Now!</a>
+  </div>
+</div>

--- a/_includes/contest/past.html
+++ b/_includes/contest/past.html
@@ -1,8 +1,5 @@
-<div class="row">
-  <div class="col-md-12 text-center">
-    <h3>2015-2016</h3>
-    <p>The inaugural year of The Contest. Check out all the <a href="/contest/2015-2016">info</a>.</p>
-    <p>The winner? <a href="https://citygro.ws/" target="_blank">CityGrows</a></p>
-  </div>
+<div class="text-center">
+  <h3>2015-2016</h3>
+  <p>The inaugural year of The Contest. Check out all the <a href="/contest/2015-2016">info</a>.</p>
+  <p>The winner? <a href="https://citygro.ws/" target="_blank">CityGrows</a></p>
 </div>
-<hr />

--- a/_includes/index/jumbotron.html
+++ b/_includes/index/jumbotron.html
@@ -2,8 +2,13 @@
 
 <p>Are you a Silicon Beach rockstar? Are you passionate about your community? Would you like to develop innovative solutions that are relevant both to Santa Monica and cities everywhere?</p>
 
-<p>Go behind the scenes with the experts at City Hall and collaborate with some of the best and brightest technology companies in town to usher in the next generation of local government. We have broad goals to achieve in the areas of <em>community</em>, <em>mobility</em>, and <em>civic engagement</em>. Will you join us?
-</p>
+<p>Go behind the scenes with the experts at City Hall and collaborate with some of the best and brightest technology companies in town to usher in the next generation of local government. We have broad goals to achieve in the areas of <em>community</em>, <em>mobility</em>, and <em>civic engagement</em>. Will you join us?</p>
 
-<p class="pull-left"><a class="btn btn-default btn-lg" href="{{ site.baseurl }}/contest/current">The Contest: 2017</a></p>
-<p class="pull-right"><a class="btn btn-default btn-lg" target="_blank" href="https://go.citygro.ws/flow_templates/982/initiated_flows/new">Apply Now!</a></p>
+<div class="row">
+    <div class="col">
+        <a class="btn btn-default btn-lg" href="{{ site.baseurl }}/contest/current">The Contest: 2017</a>
+    </div>
+    <div class="col text-sm-right">
+        <a class="btn btn-default btn-lg" target="_blank" href="https://go.citygro.ws/flow_templates/982/initiated_flows/new">Apply Now!</a>
+    </div>
+</div>

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -1,27 +1,22 @@
-<nav class="navbar navbar-inverse navbar-fixed-top">
+<nav class="navbar navbar-expand-lg navbar-dark fixed-top">
   <div class="container">
-    <div class="navbar-header">
-      <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#main-navbar-collapse" aria-expanded="false">
-        <span class="sr-only">Toggle navigation</span>
-        <span class="icon-bar"></span>
-        <span class="icon-bar"></span>
-        <span class="icon-bar"></span>
-      </button>
-      <a class="navbar-brand" href="{{ site.baseurl }}/">{% include htb.html %}</a>
-    </div>
+    <a class="navbar-brand" href="{{ site.baseurl }}/">{% include htb.html %}</a>
+    <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#main-navbar-collapse" aria-controls="main-navbar-collapse" aria-expanded="false" aria-label="Toggle navigation">
+      <span class="navbar-toggler-icon"></span>
+    </button>
     <div class="collapse navbar-collapse" id="main-navbar-collapse">
-      <ul class="nav navbar-nav navbar-right">
-        <li class="dropdown" role="presentation">
-          <a class="dropdown-toggle" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false">The Contest</a>
-          <ul class="dropdown-menu">
-            <li><a href="{{ site.baseurl }}/contest">About</a></li>
-            <li><a href="{{ site.baseurl }}/contest/current">Current: 2017</a></li>
-            <li><a href="{{ site.baseurl }}/contest/past">Past Iterations</a></li>
+      <ul class="navbar-nav ml-auto">
+        <li class="nav-item dropdown">
+          <a class="nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false" id="contestDropdown">The Contest</a>
+          <ul class="dropdown-menu" aria-labelledby="contestDropdown">
+            <li><a class="dropdown-item" href="{{ site.baseurl }}/contest">About</a></li>
+            <li><a class="dropdown-item" href="{{ site.baseurl }}/contest/current">Current: 2017</a></li>
+            <li><a class="dropdown-item" href="{{ site.baseurl }}/contest/past">Past Iterations</a></li>
           </ul>
         </li>
-        <li><a href="{{ site.baseurl }}/resources">FAQs &amp; Resources</a></li>
-        <li><a href="{{ site.baseurl }}/partners">Our Partners</a></li>
-        <li><a href="{{ site.sponsorurl }}" target="_blank">Become a Sponsor</a></li>
+        <li class="nav-item"><a class="nav-link" href="{{ site.baseurl }}/resources">FAQs &amp; Resources</a></li>
+        <li class="nav-item"><a class="nav-link" href="{{ site.baseurl }}/partners">Our Partners</a></li>
+        <li class="nav-item"><a class="nav-link" href="{{ site.sponsorurl }}" target="_blank">Become a Sponsor</a></li>
       </ul>
     </div>
   </div>

--- a/_includes/partners/partners.html
+++ b/_includes/partners/partners.html
@@ -1,4 +1,4 @@
-<div class="row partners">
+<div class="row align-items-center text-center partners">
   {% for partner in site.data.partners limit:2 %}
   <div class="col-sm-6 partner">
     {% assign logo = partner.logo %}
@@ -6,7 +6,7 @@
       {% assign logo = logo | prepend: site.baseurl %}
     {% endif %}
     <a href="{{ partner.url }}" target="_blank">
-      <img class="" alt="{{ partner.name }}" src="{{ logo }}" />
+      <img alt="{{ partner.name }}" src="{{ logo }}" />
     </a>
   </div>
   {% endfor %}
@@ -14,15 +14,15 @@
 
 <hr>
 
-<div class="row partners">
+<div class="row align-items-center text-center partners">
   {% for partner in site.data.partners offset:2 %}
-  <div class="col-sm-4 partner">
+  <div class="col-sm-6 col-md-4 my-3 partner">
     {% assign logo = partner.logo %}
     {% if logo | split: '' | first == "/" %}
       {% assign logo = logo | prepend: site.baseurl %}
     {% endif %}
     <a href="{{ partner.url }}" target="_blank">
-      <img class="" alt="{{ partner.name }}" src="{{ logo }}" />
+      <img alt="{{ partner.name }}" src="{{ logo }}" />
     </a>
   </div>
   {% endfor %}

--- a/_includes/partners/team.html
+++ b/_includes/partners/team.html
@@ -1,12 +1,12 @@
 <div class="row team rsorter">
   {% for member in site.data.team %}
-  <div class="col-sm-4 col-md-3 member sortable">
+  <div class="col-sm-4 col-md-3 member text-center sortable">
     <h3><a href="{{ member.url }}" target="_blank">{{ member.name }}</a></h3>
     {% assign logo = member.logo %}
     {% if logo | split: '' | first == "/" %}
       {% assign logo = logo | prepend: site.baseurl %}
     {% endif %}
-    <img class="img-circle img-responsive" alt="{{ member.name }} headshot" src="{{ logo }}" />
+    <img class="rounded-circle img-fluid mb-2" alt="{{ member.name }} headshot" src="{{ logo }}" />
     <p>
       <em>
         {{ member.title }}

--- a/_includes/resources/jumbotron.html
+++ b/_includes/resources/jumbotron.html
@@ -3,13 +3,13 @@
 <p>Contact us with your questions, ideas, and comments.</p>
 
 <div class="row">
-  <div class="col-sm-4">      
+  <div class="col-lg-4">      
     {% include templates/button.html text="@hackthebeach" href="https://twitter.com/hackthebeach" target="_blank" icon="twitter" icon-left="true" %}
   </div>
-  <div class="col-sm-4">
+  <div class="col-lg-4 text-lg-center">
     {% include templates/button.html text="info@hackthebeach.com" href="mailto:info@hackthebeach.com" icon="mail" icon-left="true" %}
   </div>
-  <div class="col-sm-4">
+  <div class="col-lg-4 text-lg-right">
     {% include templates/button.html text="Disqus feature" href="#disqus_thread" icon="disqus" icon-left="true" %}
   </div>
 </div>

--- a/_includes/templates/faq.html
+++ b/_includes/templates/faq.html
@@ -1,15 +1,11 @@
-<div class="panel panel-default">
-  <div class="panel-heading" role="tab" id="heading{{ include.index }}">
-    <h2 class="panel-title">
-      <span class="fi fi-fw fi-question-circle"></span>&nbsp;
-      <a role="button" data-toggle="collapse" data-parent="#{{ include.parent }}" href="#collapse{{ include.index }}" aria-expanded="false" aria-controls="collapse{{ include.index }}">
-          {{ include.question }}
-      </a>
-    </h2>
+<div class="card mb-2">
+  <div class="card-header" role="tab" id="heading{{ include.index }}">
+    <span class="fi fi-fw fi-question-circle" aria-hidden="true"></span>
+    <a role="button" data-toggle="collapse" data-parent="#{{ include.parent }}" href="#collapse{{ include.index }}" aria-expanded="false" aria-controls="collapse{{ include.index }}">
+        {{ include.question }}
+    </a>
   </div>
-  <div id="collapse{{ include.index }}" class="panel-collapse collapse" role="tabpanel" aria-labelledby="heading{{ include.index }}">
-    <div class="panel-body">
-        {{ include.answer }}
-    </div>
+  <div id="collapse{{ include.index }}" class="card-body collapse" role="tabpanel" aria-labelledby="heading{{ include.index }}">
+    {{ include.answer }}
   </div>
 </div>

--- a/_includes/templates/section.html
+++ b/_includes/templates/section.html
@@ -1,13 +1,11 @@
 {% if include.header %}
 <div class="header">
-  <div class="container">
-    <h2 class="text-center">{{ include.header }}</h2>
-  </div>
+  <h2 class="text-center m-0">{{ include.header }}</h2>
 </div>
 {% endif %}
 
 {% if include.content %}
-<div class="section {{ include.name }}">
+<div class="section my-4 {{ include.name }}">
   <div class="container">
     {% include {{ include.content }} %}
   </div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -21,7 +21,7 @@
     <script src="https://use.typekit.net/qza1fze.js"></script>
     <script>try{Typekit.load();}catch(e){}</script>
 
-    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta.2/css/bootstrap.min.css" integrity="sha384-PsH8R72JQ3SOdhVi3uxftmaW6Vc51MKb0q5P2rRUpPvrszuE4W1povHYgTpBfshb" crossorigin="anonymous">
     <script src="https://use.fonticons.com/45cfc314.js"></script>
     <link rel="stylesheet" href="{{ site.baseurl }}/css/main.css">
     <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
@@ -46,20 +46,24 @@
 
     {% include templates/section.html header="Talk About It" content="disqus.html" %}
 
-    <div class="container">
-      <hr>
-      <footer>
-        <p class="pull-left">&copy; City of Santa Monica 2017</p>
-        <p class="pull-right">
-          <a href="https://github.com/CityofSantaMonica/hackthebeach" target="_blank">
-          {% include templates/icon.html icon="code-fork" fixed=true %} Hosted with gh-pages
-          </a>
-        </p>
-      </footer>
-    </div>
+    <footer class="border border-bottom-0 border-left-0 border-right-0 py-4">
+      <div class="container">
+        <div class="row">
+          <div class="col">
+             &copy; City of Santa Monica 2017
+          </div>
+          <div class="col text-sm-right">
+            <a href="https://github.com/CityofSantaMonica/hackthebeach" target="_blank">
+              {% include templates/icon.html icon="code-fork" fixed=true %} Hosted with gh-pages
+            </a>
+          </div>
+        </div>
+      </div>
+    </footer>
 
-    <script src="https://code.jquery.com/jquery-1.11.3.min.js"></script>
-    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>
+    <script src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN" crossorigin="anonymous"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.3/umd/popper.min.js" integrity="sha384-vFJXuSJphROIrBnz7yo7oB41mKfc8JzQZiCq4NCceLEaO4IHwicKwpJf9c9IpFgh" crossorigin="anonymous"></script>
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta.2/js/bootstrap.min.js" integrity="sha384-alpBpkh1PFOepccYVYDB4do5UnbKysX5WZXm3XxPqe5iKTfUKjNkCk9SaVuEZflJ" crossorigin="anonymous"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/prefixfree/1.0.7/prefixfree.min.js"></script>
     <script src="{{ site.baseurl }}/js/main.js"></script>
     {% if page.js %}

--- a/_sass/_challenges.scss
+++ b/_sass/_challenges.scss
@@ -1,21 +1,5 @@
 .challenge {
-
-  h2, h3 {
-    margin-top: 0;
-  }
-
-  &.text-center {
-    img {
-      margin: 0 auto;
-      margin-bottom: .5em;
-    }
-  }
-
-  div:first-of-type {
-    margin-bottom: 0.5em;
-
-    img {
-      max-width: 100%;
-    }
+  h3 {
+    font-size: 1.5em;
   }
 }

--- a/_sass/_jumbotron.scss
+++ b/_sass/_jumbotron.scss
@@ -13,7 +13,6 @@
   }
   
   h1 {
-    font-size: 2em;
     font-weight: bold;
   }
 
@@ -48,19 +47,5 @@
   @media #{$screen-md} {
     min-height: 350px;
     padding: 30px 15px;
-    
-    h1 {
-      font-size: 2.5em;
-    }
-
-    p {
-      font-size: 1.5em;
-    }
-  }
-
-  @media #{$screen-lg} {
-    h1 {
-      font-size: 4em;
-    }
   }
 }

--- a/_sass/_partners.scss
+++ b/_sass/_partners.scss
@@ -1,20 +1,7 @@
 .partners,
 .team {
-  .member,
-  .partner {
-    text-align: center;
-    margin-bottom: #{$spacer};
-  }
-
   img {
-      margin: 0 auto;
-      margin-bottom: 0.5em;
-      max-height: 200px;
-      max-width: 200px;
-    }
-
-  .partner {
-    height: 207px;
-    img { line-height: 207px; }
+    max-height: 200px;
+    max-width: 200px;
   }
 }

--- a/_sass/_section.scss
+++ b/_sass/_section.scss
@@ -4,24 +4,4 @@
   font-family: $hackFont;
   font-weight: bold;
   padding: #{$spacer / 2} 0;
-  height: #{$spacer * 3};
-
-  h2 {
-    width: 100%;
-    margin: 0;
-  }
-
-  &:first-of-type,
-  &.data {
-    margin-top: 0;
-  }
-}
-
-.section {
-  padding: $sectionSpacer 0;
-}
-
-.section + .section,
-.jumbotron + .section{
-  padding-top: 0;
 }

--- a/_sass/_utilities.scss
+++ b/_sass/_utilities.scss
@@ -1,4 +1,0 @@
-// (M)argin (B)ottom 2
-.mb2 {
-    margin-bottom: 15px;
-}

--- a/css/main.scss
+++ b/css/main.scss
@@ -10,7 +10,6 @@
 @import "challenges";
 @import "partners";
 @import "judges";
-@import "utilities";
 
 body {
   font-family: $bodyFont;


### PR DESCRIPTION
Per discussions in #13, here's the B4 move

- *Mostly* everything has been ported to Bootstrap; there are a few kinks here and there
  - [ ] Navigation bar on mobile changed from B3 to B4, so a workaround to keep similar functionality is needed?
  - [ ] Jumbotron can use some love
- Replaced a lot of our own custom CSS with dedicated B4 helper classes
- Added livereload Jekyll plugin. Since the Gemfile is ignored by GH, we can use it for easier local dev until livereload is built-in to Jekyll

Can I get help testing the site at different resolutions and find more quirks that need fixing?